### PR TITLE
Fix: AudioFormatType for g711 u-law and 6711 a-law

### DIFF
--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -1,6 +1,6 @@
 /**
  * Valid audio formats
- * @typedef {"pcm16"|"g711-ulaw"|"g711-alaw"} AudioFormatType
+ * @typedef {"pcm16"|"g711_ulaw"|"g711_alaw"} AudioFormatType
  */
 /**
  * @typedef {Object} AudioTranscriptionType
@@ -312,7 +312,7 @@ export class RealtimeClient extends RealtimeEventHandler {
 /**
  * Valid audio formats
  */
-export type AudioFormatType = "pcm16" | "g711-ulaw" | "g711-alaw";
+export type AudioFormatType = "pcm16" | "g711_ulaw" | "g711_alaw";
 export type AudioTranscriptionType = {
     enabled?: boolean;
     model: "whisper-1";


### PR DESCRIPTION
Per the OpenAI Docs [here](https://platform.openai.com/docs/api-reference/realtime-client-events/session-update), and errors returned from the websockets API, `g711-ulaw` and `g711-alaw` are not valid Audio format types. The expected value is `g711_ulaw` and `g711_alaw`. 

Closes #8  

cc @khorwood-openai 