### PR TITLE
Use it with Azure OpenAI

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -113,13 +113,14 @@ export class RealtimeAPI extends RealtimeEventHandler {
       const wsModule = await import(/* webpackIgnore: true */ moduleName);
       const WebSocket = wsModule.default;
       const ws = new WebSocket(
-        'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01',
+        `${this.url}`,
         [],
         {
           finishRequest: (request) => {
             // Auth
             request.setHeader('Authorization', `Bearer ${this.apiKey}`);
             request.setHeader('OpenAI-Beta', 'realtime=v1');
+            request.setHeader("api-key", this.apiKey);
             request.end();
           },
         },


### PR DESCRIPTION
This pull request updates the RealtimeAPI class in lib/api.js to support other URLs, such as Azure OpenAI.

Changes:
- Updated WebSocket URL to be dynamic (this.url). (lib/api.js)
- Added api-key header for Azure OpenAI. (lib/api.js)
