### PR TITLE
Bugfix/issue 27 invalid item access

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -274,6 +274,9 @@ export class RealtimeClient extends RealtimeEventHandler {
 
     // Setup for application control flow
     const handler = (event, ...args) => {
+      if (!this.realtime.isConnected()) {
+        return { item: null, delta: null };
+      }
       const { item, delta } = this.conversation.processEvent(event, ...args);
       return { item, delta };
     };
@@ -329,6 +332,9 @@ export class RealtimeClient extends RealtimeEventHandler {
     // Handlers to update application state
     this.realtime.on('server.conversation.item.created', (event) => {
       const { item } = handlerWithDispatch(event);
+      if (!item) {
+        return;
+      }
       this.dispatch('conversation.item.appended', { item });
       if (item.status === 'completed') {
         this.dispatch('conversation.item.completed', { item });
@@ -352,6 +358,9 @@ export class RealtimeClient extends RealtimeEventHandler {
     );
     this.realtime.on('server.response.output_item.done', async (event) => {
       const { item } = handlerWithDispatch(event);
+      if (!item) {
+        return;
+      }
       if (item.status === 'completed') {
         this.dispatch('conversation.item.completed', { item });
       }

--- a/test/tests/client_disconnect.js
+++ b/test/tests/client_disconnect.js
@@ -1,0 +1,33 @@
+import * as chai from 'chai';
+const expect = chai.expect;
+
+import { RealtimeClient } from '../../index.js';
+
+export async function run({ debug = false } = {}) {
+  describe('RealtimeClient (Node.js) - Disconnect', () => {
+    
+    it('Should not throw an error if the client disconnects while receiving messages', async function() {
+        this.timeout(10000);
+        const client = new RealtimeClient({
+          apiKey: process.env.OPENAI_API_KEY,
+          debug,
+        });
+  
+        client.realtime.on('server.response.audio.delta', () => {
+          client.disconnect();
+        });
+  
+        await client.connect();
+        await client.waitForSessionCreated();
+  
+        client.sendUserMessageContent([{ type: 'input_text', text: 'Hello' }]);
+
+        await client.waitForNextCompletedItem();
+        
+  
+        expect(client).to.exist;
+      
+      });
+    });
+
+}


### PR DESCRIPTION
Fix for issue #27 

Scheduled event handlers can run after a call to `disconnect` on the client. The conversation object has been cleared so item lookups cause an error to be thrown in some handlers.

With these changes, the event handler function returns early if the client is not connected, before trying to look up items.

A test case has been added, however the error triggers after the successful completion of the test. Not sure how to wait for all scheduled event handlers to run in the test.