### PR TITLE
fix usage with cloudflare workers

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -63,11 +63,11 @@ export class RealtimeAPI extends RealtimeEventHandler {
     if (this.isConnected()) {
       throw new Error(`Already connected`);
     }
-    if (globalThis.document) {
+    if (globalThis.WebSocket) {
       /**
        * Web browser
        */
-      if (this.apiKey) {
+      if (globalThis.document && this.apiKey) {
         console.warn(
           'Warning: Connecting using API key in the browser, this is not recommended',
         );


### PR DESCRIPTION
Cloudflare Workers (and other runtimes, including Node v22+) have a native global standards based Websocket class. This patch detects it and uses it when available.