### PR TITLE
fix: pass model on to .connect()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -387,13 +387,14 @@ export class RealtimeClient extends RealtimeEventHandler {
   /**
    * Connects to the Realtime WebSocket API
    * Updates session config and conversation config
+   * @param {{model?: string|undefined}} [settings]
    * @returns {Promise<true>}
    */
-  async connect() {
+  async connect({ model } = {}) {
     if (this.isConnected()) {
       throw new Error(`Already connected, use .disconnect() first`);
     }
-    await this.realtime.connect();
+    await this.realtime.connect({ model });
     this.updateSession();
     return true;
   }


### PR DESCRIPTION
the `.connect()` method in `api.js` accepts a `{model: string}` param, but the client doesn't appear to pass it. This adds it on.