### PR TITLE
Adds support for extended web socket protocols to client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -189,9 +189,15 @@ import { RealtimeUtils } from './utils.js';
 export class RealtimeClient extends RealtimeEventHandler {
   /**
    * Create a new RealtimeClient instance
-   * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean}} [settings]
+   * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean, extendedWebSocketProtocols: Array<string>}} [settings]
    */
-  constructor({ url, apiKey, dangerouslyAllowAPIKeyInBrowser, debug } = {}) {
+  constructor({
+    url,
+    apiKey,
+    dangerouslyAllowAPIKeyInBrowser,
+    debug,
+    extendedWebSocketProtocols,
+  } = {}) {
     super();
     this.defaultSessionConfig = {
       modalities: ['text', 'audio'],
@@ -223,6 +229,7 @@ export class RealtimeClient extends RealtimeEventHandler {
       apiKey,
       dangerouslyAllowAPIKeyInBrowser,
       debug,
+      extendedWebSocketProtocols,
     });
     this.conversation = new RealtimeConversation();
     this._resetConfig();


### PR DESCRIPTION
https://holidayextras.jira.com/browse/HEHA-3314
This pull request includes a few changes to the `RealtimeClient` class in the `lib/client.js` file to support extended WebSocket protocols. The most important changes are:

Enhancements to `RealtimeClient` class:

* Added `extendedWebSocketProtocols` to the `settings` parameter of the `RealtimeClient` constructor.
* Updated the initialization of `this.defaultSessionConfig` to include `extendedWebSocketProtocols`.

This is to enable the client to pass an api key to the apigee gateway. 