### PR TITLE
Feat: Support new 5 voices

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -35,7 +35,7 @@ import { RealtimeUtils } from './utils.js';
  * @property {string} [model]
  * @property {string[]} [modalities]
  * @property {string} [instructions]
- * @property {"alloy"|"shimmer"|"echo"} [voice]
+ * @property {"alloy"|"ash"|"ballad"|"coral"|"echo"|"sage"|"shimmer"|"verse"} [voice]
  * @property {AudioFormatType} [input_audio_format]
  * @property {AudioFormatType} [output_audio_format]
  * @property {AudioTranscriptionType|null} [input_audio_transcription]


### PR DESCRIPTION
## Changes

- Added support for five new voices introduced in the Realtime API update on October 30th.

>The voice the model uses to respond. Supported voices are ***alloy, ash, ballad, coral, echo, sage, shimmer, and verse***. Cannot be changed once the model has responded with audio at least once.
https://platform.openai.com/docs/api-reference/realtime-client-events/session/update

<img width="625" alt="image" src="https://github.com/user-attachments/assets/4ecba256-b116-437a-a6a1-d6ec95cd8f11">

## Related Issue
- #61 

