### PR TITLE
modify constructor to allow specifying model to use

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -4,15 +4,16 @@ import { RealtimeUtils } from './utils.js';
 export class RealtimeAPI extends RealtimeEventHandler {
   /**
    * Create a new RealtimeAPI instance
-   * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean}} [settings]
+   * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean, model?: string}} [settings]
    * @returns {RealtimeAPI}
    */
-  constructor({ url, apiKey, dangerouslyAllowAPIKeyInBrowser, debug } = {}) {
+  constructor({ url, apiKey, dangerouslyAllowAPIKeyInBrowser, debug, model } = {}) {
     super();
     this.defaultUrl = 'wss://api.openai.com/v1/realtime';
     this.url = url || this.defaultUrl;
     this.apiKey = apiKey || null;
     this.debug = !!debug;
+    this.model = model || 'gpt-4o-realtime-preview';
     this.ws = null;
     if (globalThis.document && this.apiKey) {
       if (!dangerouslyAllowAPIKeyInBrowser) {
@@ -56,13 +57,15 @@ export class RealtimeAPI extends RealtimeEventHandler {
    * @param {{model?: string}} [settings]
    * @returns {Promise<true>}
    */
-  async connect({ model } = { model: 'gpt-4o-realtime-preview-2024-10-01' }) {
+  async connect({ model } = {}) {
     if (!this.apiKey && this.url === this.defaultUrl) {
       console.warn(`No apiKey provided for connection to "${this.url}"`);
     }
     if (this.isConnected()) {
       throw new Error(`Already connected`);
     }
+    const useModel = model || this.model;
+    
     if (globalThis.WebSocket) {
       /**
        * Web browser
@@ -73,7 +76,7 @@ export class RealtimeAPI extends RealtimeEventHandler {
         );
       }
       const WebSocket = globalThis.WebSocket;
-      const ws = new WebSocket(`${this.url}${model ? `?model=${model}` : ''}`, [
+      const ws = new WebSocket(`${this.url}${useModel ? `?model=${useModel}` : ''}`, [
         'realtime',
         `openai-insecure-api-key.${this.apiKey}`,
         'openai-beta.realtime-v1',
@@ -113,7 +116,7 @@ export class RealtimeAPI extends RealtimeEventHandler {
       const wsModule = await import(/* webpackIgnore: true */ moduleName);
       const WebSocket = wsModule.default;
       const ws = new WebSocket(
-        'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01',
+        `${this.url}${useModel ? `?model=${useModel}` : ''}`,
         [],
         {
           finishRequest: (request) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -189,10 +189,11 @@ import { RealtimeUtils } from './utils.js';
 export class RealtimeClient extends RealtimeEventHandler {
   /**
    * Create a new RealtimeClient instance
-   * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean}} [settings]
+   * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean, model?: string}} [settings]
    */
-  constructor({ url, apiKey, dangerouslyAllowAPIKeyInBrowser, debug } = {}) {
+  constructor({ url, apiKey, dangerouslyAllowAPIKeyInBrowser, debug, model } = {}) {
     super();
+    this.defaultModel = model || 'gpt-4o-realtime-preview';
     this.defaultSessionConfig = {
       modalities: ['text', 'audio'],
       instructions: '',
@@ -223,6 +224,7 @@ export class RealtimeClient extends RealtimeEventHandler {
       apiKey,
       dangerouslyAllowAPIKeyInBrowser,
       debug,
+      model: this.defaultModel,
     });
     this.conversation = new RealtimeConversation();
     this._resetConfig();


### PR DESCRIPTION
Close #89 

Issue:
- It won't allow using other models than the hardcoded model `gpt-4o-realtime-preview-2024-10-01`
- A new model `gpt-4o-realtime-preview-2024-12-17` has been released with lower price.
- Alias `gpt-4o-realtime-preview` is also available

Expected:
- Library consumers should be able to specify models they choose
- The library should point model alias instead of a specific dated model